### PR TITLE
Added --skip-worktree to postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "n. - A storage pile accumulated for future use",
   "author": "tommy-carlos williams <tommy@devgeeks.org>",
   "scripts": {
+    "postinstall": "git update-index --skip-worktree ./src/utils/config.js",
     "dev": "node build/dev-server.js",
     "start": "node build/dev-server.js",
     "build": "node build/build.js",


### PR DESCRIPTION
This will run `git update-index --skip-worktree ./src/utils/config.js`
after `npm install`.

This keeps the local changes in `./src/utils/config.js` (such as ones
API KEY) from being tracked and accidentally uploaded to GitHub, etc.

This might help with #16, but it isn't a complete solution.